### PR TITLE
Add https scheme to URI

### DIFF
--- a/roles/provision-fh-sync-server-apb/templates/secret.yml.j2
+++ b/roles/provision-fh-sync-server-apb/templates/secret.yml.j2
@@ -6,4 +6,5 @@ metadata:
 stringData:
   name: {{ fhsync_secret_display_name }}
   type: {{ fhsync_secret_display_name }}
-  uri: {{ fhsync_route.stdout }}
+  uri: https://{{ fhsync_route.stdout }}
+


### PR DESCRIPTION
I see that the `secret` currently misses the `https://` - however this is present in the _old_ template based approach, hence I am adding it here as well 