### PR TITLE
Fix secret contents

### DIFF
--- a/roles/provision-fh-sync-server-apb/defaults/main.yml
+++ b/roles/provision-fh-sync-server-apb/defaults/main.yml
@@ -1,4 +1,4 @@
 fhsync_deploy_template: "https://raw.githubusercontent.com/feedhenry/fh-sync-server/master/fh-sync-server-DEVELOPMENT.yaml"
 fhsync_port: "3000"
-fhsync_secret_display_name: "fhsync"
+fhsync_secret_name: "fh-sync-server"
 

--- a/roles/provision-fh-sync-server-apb/templates/secret.yml.j2
+++ b/roles/provision-fh-sync-server-apb/templates/secret.yml.j2
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ fhsync_secret_display_name }}
+  name: {{ fhsync_secret_name }}
   namespace: {{ namespace }}
 stringData:
-  name: {{ fhsync_secret_display_name }}
-  type: {{ fhsync_secret_display_name }}
+  name: {{ fhsync_secret_name }}
+  type: {{ fhsync_secret_name }}
   uri: https://{{ fhsync_route.stdout }}
 


### PR DESCRIPTION
Currently the secret will not appear in the Mobile Control Panel,
the reason for this is that the Mobile Control Panel is expecting
the type of the service to be fh-sync-server and not fhsync.

The name field also needs to be updated to allow the icon for the
service to be discovered.

Finally, the name of the secret has been updated to match with the
other two values.